### PR TITLE
For stdin/stdout case, shutdown the process on client.shutdown()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "development-tools"]
 
 [dependencies]
 serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.137"
+serde_json = "^1.0.137"
 tokio = { version = "1.42.0", features = ["full"] }
 async-trait = "0.1.85"
 thiserror = "2.0.9"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -135,7 +135,7 @@ impl ClientBuilder {
 
         tracing::debug!("Creating StdioTransport");
         let transport = StdioTransport::with_streams(child_stdout, child_stdin)?;
-        let client = Client::new(Arc::new(transport));
+        let client = Client::new(Arc::new(transport), Some(child));
 
         let implementation = self.implementation.unwrap_or_else(|| {
             let default_impl = Implementation {

--- a/src/types.rs
+++ b/src/types.rs
@@ -338,7 +338,7 @@ pub struct GetPromptResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolResult {
     pub content: Vec<MessageContent>,
-    #[serde(rename = "isError")]
+    #[serde(rename = "isError", default)]
     pub is_error: bool,
 }
 


### PR DESCRIPTION
...the other case is remote MCP which I believe Anthropic is about to release, so we'll need more updates, but for now we need to make sure the simple case of local stdin/stdout subprocess works right.

These changes are kind of tested:

```
085642.323 INFO mcp_client_rust/src/client/mod.rs:219 Shutting down MCP client
085642.323 INFO mcp_client_rust/src/client/mod.rs:223 Have an associated subprocess, waiting for 2 seconds
085644.326 INFO mcp_client_rust/src/client/mod.rs:227 Have an associated subprocess, sending kill and waiting for 2 seconds
085644.346 INFO mcp_client_rust/src/client/mod.rs:231 Exit code from subprocess Ok(Some(ExitStatus(unix_wait_status(9))))
```

But maybe there's a message in the protocol to ask server to shut down even more politely, but then the server is free to ignore it, so this code is needed anyway.
