### PR TITLE
Fix/default is error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "development-tools"]
 
 [dependencies]
 serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.137"
+serde_json = "^1.0.137"
 tokio = { version = "1.42.0", features = ["full"] }
 async-trait = "0.1.85"
 thiserror = "2.0.9"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -135,7 +135,7 @@ impl ClientBuilder {
 
         tracing::debug!("Creating StdioTransport");
         let transport = StdioTransport::with_streams(child_stdout, child_stdin)?;
-        let client = Client::new(Arc::new(transport));
+        let client = Client::new(Arc::new(transport), Some(child));
 
         let implementation = self.implementation.unwrap_or_else(|| {
             let default_impl = Implementation {

--- a/src/types.rs
+++ b/src/types.rs
@@ -338,7 +338,7 @@ pub struct GetPromptResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolResult {
     pub content: Vec<MessageContent>,
-    #[serde(rename = "isError")]
+    #[serde(rename = "isError", default)]
     pub is_error: bool,
 }
 


### PR DESCRIPTION
Some mcp servers don't send isError field if there was no error, like github mcp server https://github.com/modelcontextprotocol/servers/tree/main/src/github, so if they don't send it, we may assume it's false